### PR TITLE
Make logo injection more robust

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,7 +1,7 @@
 require(['gitbook', 'jQuery'], function (gitbook, $) {
   var url = ''
   var insertLogo = function (url) {
-    $('#book-search-input').before('<div class="book-logo"><img src=\"' + url + '"</div>')
+    $('.book-summary').children().eq(0).before('<div class="book-logo"><img src=\"' + url + '"</div>')
   }
   gitbook.events.bind('start', function (e, config) {
     url = config['insert-logo']['url']


### PR DESCRIPTION
Hey there!

Thanks for maintaining this plugin!

This patch removes the assumption that `#book-search-input` is the first child of `.book-summary`, or that it exists at all.

This can happen when `search` and `lunr` are removed as plugins.